### PR TITLE
Fixed progress bar not works in iOS11.0.1

### DIFF
--- a/InstagramStories/Source/StoryHeaderView & ProgressView/IGStoryPreviewHeaderView.swift
+++ b/InstagramStories/Source/StoryHeaderView & ProgressView/IGStoryPreviewHeaderView.swift
@@ -225,6 +225,7 @@ final class IGStoryPreviewHeaderView: UIView {
             NSLayoutConstraint.activate([
                 pv.leftAnchor.constraint(equalTo: pvIndicator.leftAnchor),
                 pv.heightAnchor.constraint(equalTo: pvIndicator.heightAnchor),
+                pv.topAnchor.constraint(equalTo: pvIndicator.topAnchor),
                 pv.widthConstraint!
                 ])
         }


### PR DESCRIPTION
# PR Details

Modified auto layout constraints in IGStoryPreviewHeaderView to make progress bar works in iOS 11.0.1

## Description

Progress bar not worked in iOS 11.0.1 which is a bug. We have fixed that issue by modified the Autolayout constraints.

## Motivation and Context

This changes will make progress bar works.
